### PR TITLE
Update upstream/CVE-2019-11250.json

### DIFF
--- a/upstream/CVE-2019-11250.json
+++ b/upstream/CVE-2019-11250.json
@@ -1,0 +1,44 @@
+{
+  "id": "CVE-2019-11250",
+  "modified": "2019-08-08T02:03:04Z",
+  "published": "2019-08-08T02:03:04Z",
+  "summary": "Bearer tokens are revealed in logs",
+  "details": "The Kubernetes client-go library logs request headers at verbosity levels of 7 or higher. This can disclose credentials to unauthorized users via logs or command output. Kubernetes components (such as kube-apiserver) prior to v1.16.0, which make use of basic or bearer token authentication, and run at high verbosity levels, are affected.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "kubernetes",
+        "name": "k8s.io/apiserver"
+      },
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.0/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:N/A:N"
+        }
+      ],
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.16.0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/kubernetes/kubernetes/issues/81114"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://www.cve.org/cverecord?id=CVE-2019-11250"
+    }
+  ]
+}


### PR DESCRIPTION
This PR updates upstream/CVE-2019-11250.json